### PR TITLE
Add route tables to subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,53 @@ resource "azurerm_network_security_group" "ssh" {
 }
 ```
 
+## Example adding a route table
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "my-resources"
+  location = "West Europe"
+}
+
+module "vnet" {
+  source              = "Azure/vnet/azurerm"
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  subnet_names        = ["subnet1", "subnet2", "subnet3"]
+
+  route_table_ids = {
+    subnet1 = azurerm_route_table.example.id 
+    subnet2 = azurerm_route_table.example.id
+    subnet3 = azurerm_roiute_table.example.id
+  }
+
+
+  tags = {
+    environment = "dev"
+    costcenter  = "it"
+  }
+}
+
+resource "azurerm_route_table" "example" {
+  location            = azurerm_resource_group.example.location
+  name                = "MyRouteTable"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_route" "example" {
+  name                = "acceptanceTestRoute1"
+  resource_group_name = azurerm_resource_group.example.name
+  route_table_name    = azurerm_route_table.example.name
+  address_prefix      = "10.1.0.0/16"
+  next_hop_type       = "vnetlocal"
+}
+
+```
 ## Test
 
 ### Configurations

--- a/main.tf
+++ b/main.tf
@@ -34,3 +34,9 @@ resource "azurerm_subnet_network_security_group_association" "vnet" {
   subnet_id                 = data.azurerm_subnet.import[each.key].id
   network_security_group_id = each.value
 }
+
+resource "azurerm_subnet_route_table_association" "vnet" {
+  for_each = var.route_tables_ids
+  route_table_id = each.value
+  subnet_id = data.azurerm_subnet.import[each.key].id
+}

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_subnet_network_security_group_association" "vnet" {
 }
 
 resource "azurerm_subnet_route_table_association" "vnet" {
-  for_each = var.route_tables_ids
+  for_each       = var.route_tables_ids
   route_table_id = each.value
-  subnet_id = data.azurerm_subnet.import[each.key].id
+  subnet_id      = data.azurerm_subnet.import[each.key].id
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -18,8 +18,8 @@ resource "azurerm_network_security_group" "nsg1" {
 }
 
 resource "azurerm_route_table" "rt1" {
-  location = azurerm_resource_group.test.location
-  name = "test-${random_id.rg_name.hex}-rt"
+  location            = azurerm_resource_group.test.location
+  name                = "test-${random_id.rg_name.hex}-rt"
   resource_group_name = azurerm_resource_group.test.name
 }
 

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -17,6 +17,12 @@ resource "azurerm_network_security_group" "nsg1" {
   location            = azurerm_resource_group.test.location
 }
 
+resource "azurerm_route_table" "rt1" {
+  location = azurerm_resource_group.test.location
+  name = "test-${random_id.rg_name.hex}-rt"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
 module "vnet" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test.name
@@ -26,6 +32,10 @@ module "vnet" {
 
   nsg_ids = {
     subnet1 = azurerm_network_security_group.nsg1.id
+  }
+
+  route_tables_ids = {
+    subnet1 = azurerm_route_table.rt1.id
   }
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "nsg_ids" {
   }
 }
 
+variable "route_tables_ids" {
+  description = "A map of subnet name to Route table ids"
+  type = map(string)
+  default = {}
+}
+
 variable "tags" {
   description = "The tags to associate with your network and subnets."
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -39,8 +39,8 @@ variable "nsg_ids" {
 
 variable "route_tables_ids" {
   description = "A map of subnet name to Route table ids"
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 variable "tags" {


### PR DESCRIPTION
Currently we can't attach a route table on a subnet.
I've added this option with one more variable "route_tables_ids" which is empty by default. To attach a route table, add it in the list like for subnet creation or prefix definition : `route_tables_ids = ["subnet1_route_id", "subnet2_route_id", ...]` 