### PR TITLE
Support Azurerm 2.0 and removal of resource group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 env:
-  - TERRAFORM_VERSION=0.11.7 IMAGE_NAME=azure-vnet-module
+  - TERRAFORM_VERSION=0.12.10 IMAGE_NAME=azure-vnet-module
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 env:
-  - TERRAFORM_VERSION=0.12.10 IMAGE_NAME=azure-vnet-module
+  - TERRAFORM_VERSION=0.12.20 IMAGE_NAME=azure-vnet-module
 
 jobs:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull the base image with given version.
-ARG BUILD_TERRAFORM_VERSION="0.12.10"
+ARG BUILD_TERRAFORM_VERSION="0.12.20"
 FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 
 ARG MODULE_NAME="terraform-azurerm-vnet"
@@ -32,6 +32,5 @@ WORKDIR /go/src/${MODULE_NAME}
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
 RUN /bin/bash -c "curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh"
-RUN terraform init
 
 RUN ["bundle", "install", "--gemfile", "./Gemfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Pull the base image with given version.
-ARG BUILD_TERRAFORM_VERSION="0.11.7"
-FROM microsoft/terraform-test:${BUILD_TERRAFORM_VERSION}
+ARG BUILD_TERRAFORM_VERSION="0.12.10"
+FROM mcr.microsoft.com/terraform-test:${BUILD_TERRAFORM_VERSION}
 
 ARG MODULE_NAME="terraform-azurerm-vnet"
 
@@ -32,5 +32,6 @@ WORKDIR /go/src/${MODULE_NAME}
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
 RUN /bin/bash -c "curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh"
+RUN terraform init
 
 RUN ["bundle", "install", "--gemfile", "./Gemfile"]

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org/'
 
 group :test do
   git 'https://github.com/Azure/terramodtest.git' do
-    gem 'terramodtest', :tag => 'v0.2.0'
+    gem 'terramodtest', :tag => 'v0.3.0'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
-ruby "~> 2.3.0"
-
 source 'https://rubygems.org/'
 
 group :test do
   git 'https://github.com/Azure/terramodtest.git' do
-    gem 'terramodtest', :tag => 'v0.3.0'
+    gem 'terramodtest', tag: '0.4.0'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org/'
 
 group :test do
   git 'https://github.com/Azure/terramodtest.git' do
-    gem 'terramodtest', tag: '0.4.0'
+    gem 'terramodtest', tag: '0.5.0'
   end
 end

--- a/README.md
+++ b/README.md
@@ -11,32 +11,15 @@ The module does not create nor expose a security group. This would need to be de
 ## Usage
 
 ```hcl
-module "vnet" {
-    source              = "Azure/vnet/azurerm"
-    resource_group_name = "myapp"
-    location            = "westus"
-    address_space       = "10.0.0.0/16"
-    subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-    subnet_names        = ["subnet1", "subnet2", "subnet3"]
-
-    tags                = {
-                            environment = "dev"
-                            costcenter  = "it"
-                          }
+resource "azurerm_resource_group" "example" {
+  name     = "my-resources"
+  location = "West Europe"
 }
-
-```
-
-## Example adding a network security rule for SSH
-
-```hcl
-variable "resource_group_name" { }
 
 module "vnet" {
   source              = "Azure/vnet/azurerm"
-  resource_group_name = "${var.resource_group_name}"
-  location            = "westus"
-  address_space       = "10.0.0.0/16"
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
 
@@ -46,12 +29,34 @@ module "vnet" {
   }
 }
 
-resource "azurerm_subnet" "subnet" {
-  name  = "subnet1"
-  address_prefix = "10.0.1.0/24"
-  resource_group_name = "${var.resource_group_name}"
-  virtual_network_name = "acctvnet"
-  network_security_group_id = "${azurerm_network_security_group.ssh.id}"
+```
+
+## Example adding a network security rule for SSH
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "my-resources"
+  location = "West Europe"
+}
+
+module "vnet" {
+  source              = "Azure/vnet/azurerm"
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  subnet_names        = ["subnet1", "subnet2", "subnet3"]
+
+  nsg_ids = {
+    subnet1 = azurerm_network_security_group.ssh.id
+    subnet2 = azurerm_network_security_group.ssh.id
+    subnet3 = azurerm_network_security_group.ssh.id
+  }
+
+
+  tags = {
+    environment = "dev"
+    costcenter  = "it"
+  }
 }
 
 resource "azurerm_network_security_group" "ssh" {

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The module does not create nor expose a security group. This would need to be de
 ## Usage
 
 ```hcl
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "example" {
   name     = "my-resources"
   location = "West Europe"
@@ -34,6 +38,10 @@ module "vnet" {
 ## Example adding a network security rule for SSH
 
 ```hcl
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "example" {
   name     = "my-resources"
   location = "West Europe"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Then simply run it in local shell:
 $ cd $GOPATH/src/{directory_name}/
 $ bundle install
 $ rake build
-$ rake e2e
+$ rake full
 ```
 
 ### Docker

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,34 @@
 #Azure Generic vNet Module
-resource "azurerm_resource_group" "vnet" {
-  name     = "${var.resource_group_name}"
-  location = "${var.location}"
+data azurerm_resource_group "vnet" {
+  name = var.resource_group_name
 }
 
-resource "azurerm_virtual_network" "vnet" {
-  name                = "${var.vnet_name}"
-  location            = "${var.location}"
-  address_space       = ["${var.address_space}"]
-  resource_group_name = "${azurerm_resource_group.vnet.name}"
-  dns_servers         = "${var.dns_servers}"
-  tags                = "${var.tags}"
+resource azurerm_virtual_network "vnet" {
+  name                = var.vnet_name
+  resource_group_name = data.azurerm_resource_group.vnet.name
+  location            = data.azurerm_resource_group.vnet.location
+  address_space       = var.address_space
+  dns_servers         = var.dns_servers
+  tags                = var.tags
 }
 
 resource "azurerm_subnet" "subnet" {
-  name                      = "${var.subnet_names[count.index]}"
-  virtual_network_name      = "${azurerm_virtual_network.vnet.name}"
-  resource_group_name       = "${azurerm_resource_group.vnet.name}"
-  address_prefix            = "${var.subnet_prefixes[count.index]}"
-  network_security_group_id = "${lookup(var.nsg_ids,var.subnet_names[count.index],"")}"
-  count                     = "${length(var.subnet_names)}"
+  count                = length(var.subnet_names)
+  name                 = var.subnet_names[count.index]
+  resource_group_name  = data.azurerm_resource_group.vnet.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefix       = var.subnet_prefixes[count.index]
+}
+
+data "azurerm_subnet" "import" {
+  for_each             = var.nsg_ids
+  name                 = each.key
+  resource_group_name  = data.azurerm_resource_group.vnet.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "vnet" {
+  for_each                  = var.nsg_ids
+  subnet_id                 = data.azurerm_subnet.import[each.key].id
+  network_security_group_id = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,14 @@ data "azurerm_subnet" "import" {
   name                 = each.key
   resource_group_name  = data.azurerm_resource_group.vnet.name
   virtual_network_name = azurerm_virtual_network.vnet.name
+
+  depends_on = ["azurerm_subnet.subnet"]
 }
 
 resource "azurerm_subnet_network_security_group_association" "vnet" {
   for_each                  = var.nsg_ids
   subnet_id                 = data.azurerm_subnet.import[each.key].id
   network_security_group_id = each.value
+
+  depends_on = ["data.azurerm_subnet.import"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
 output "vnet_id" {
   description = "The id of the newly created vNet"
-  value       = "${azurerm_virtual_network.vnet.id}"
+  value       = azurerm_virtual_network.vnet.id
 }
 
 output "vnet_name" {
   description = "The Name of the newly created vNet"
-  value       = "${azurerm_virtual_network.vnet.name}"
+  value       = azurerm_virtual_network.vnet.name
 }
 
 output "vnet_location" {
   description = "The location of the newly created vNet"
-  value       = "${azurerm_virtual_network.vnet.location}"
+  value       = azurerm_virtual_network.vnet.location
 }
 
 output "vnet_address_space" {
   description = "The address space of the newly created vNet"
-  value       = "${azurerm_virtual_network.vnet.address_space}"
+  value       = azurerm_virtual_network.vnet.address_space
 }
 
 output "vnet_subnets" {
   description = "The ids of subnets created inside the newl vNet"
-  value       = "${azurerm_subnet.subnet.*.id}"
+  value       = azurerm_subnet.subnet.*.id
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  features {}
+}
+
 resource "random_id" "rg_name" {
   byte_length = 8
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -1,13 +1,27 @@
-module "network" {
+resource "random_id" "rg_name" {
+  byte_length = 8
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "test-${random_id.rg_name.hex}-rg"
+  location = var.location
+}
+
+resource "azurerm_network_security_group" "nsg1" {
+  name                = "test-${random_id.rg_name.hex}-nsg"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+module "vnet" {
   source              = "../../"
-  resource_group_name = "${random_id.rg_name.hex}"
-  location            = "${var.location}"
-  address_space       = "10.0.0.0/16"
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
 
   nsg_ids = {
-    subnet1 = "${azurerm_network_security_group.nsg1.id}"
+    subnet1 = azurerm_network_security_group.nsg1.id
   }
 
   tags = {
@@ -16,18 +30,5 @@ module "network" {
   }
 }
 
-resource "random_id" "rg_name" {
-  byte_length = 8
-}
 
-//Create a resource group and nsg to use for testing nsg association.
-resource "azurerm_resource_group" "myapp2" {
-  name     = "${random_id.rg_name.hex}"
-  location = "${var.location}"
-}
 
-resource "azurerm_network_security_group" "nsg1" {
-  name                = "nsg1"
-  resource_group_name = "${azurerm_resource_group.myapp2.name}"
-  location            = "${azurerm_resource_group.myapp2.location}"
-}

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -1,3 +1,3 @@
 output "test_vnet_id" {
-  value = "${module.network.vnet_id}"
+  value = module.vnet.vnet_id
 }

--- a/test/fixture/variables.tf
+++ b/test/fixture/variables.tf
@@ -1,3 +1,1 @@
-variable "location" {
-  default = "eastus"
-}
+variable "location" {}

--- a/variables.tf
+++ b/variables.tf
@@ -4,18 +4,13 @@ variable "vnet_name" {
 }
 
 variable "resource_group_name" {
-  description = "Default resource group name that the network will be created in."
-  default     = "myapp-rg"
-}
-
-variable "location" {
-  description = "The location/region where the core network will be created. The full list of Azure regions can be found at https://azure.microsoft.com/regions"
-  default     = "westus"
+  description = "Name of the resource group to be imported."
 }
 
 variable "address_space" {
+  type        = list(string)
   description = "The address space that is used by the virtual network."
-  default     = "10.0.0.0/16"
+  default     = ["10.0.0.0/16"]
 }
 
 # If no values specified, this defaults to Azure DNS 
@@ -36,20 +31,17 @@ variable "subnet_names" {
 
 variable "nsg_ids" {
   description = "A map of subnet name to Network Security Group IDs"
-  type        = "map"
+  type        = map(string)
 
   default = {
-    subnet1 = "nsgid1"
-    subnet3 = "nsgid3"
   }
 }
 
 variable "tags" {
   description = "The tags to associate with your network and subnets."
-  type        = "map"
+  type        = map(string)
 
   default = {
-    tag1 = ""
-    tag2 = ""
+    ENV = "test"
   }
 }


### PR DESCRIPTION
1. Removal of resource group
fix:
https://github.com/Azure/terraform-azurerm-vnet/issues/12
https://github.com/Azure/terraform-azurerm-vnet/issues/16

2. Bad example in README
fix:
https://github.com/Azure/terraform-azurerm-vnet/issues/13

3.`network_security_group_id` on `azurerm_subnet` resources is deprecated
fix https://github.com/Azure/terraform-azurerm-vnet/issues/15

4. address_space use original list of string
fix https://github.com/Azure/terraform-azurerm-vnet/issues/21

5. Allow create `vnet` without nsg
fix https://github.com/Azure/terraform-azurerm-vnet/issues/23