### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ module "vnet" {
 }
 
 resource "azurerm_network_security_group" "ssh" {
-  depends_on          = [module.vnet]
   name                = "ssh"
   location            = "westus"
   resource_group_name = "${var.resource_group_name}"


### PR DESCRIPTION
Example provided includes the security group in the vnet definition, and the security group depends on the vnet definition creating a circular dependency and causing terraform plan to fail to execute when running this piece of code. Remove the depends_on rule in the security group to resolve the circular dependency.