### PR TITLE
Allow configure enforce_private_link_endpoint_network_policies and enforce_private_link_service_network_policies params for subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,64 @@ resource "azurerm_route" "example" {
 }
 
 ```
+
+## Example configuring private link endpoint network policy
+
+```hcl
+module "vnet" {
+  source              = "Azure/vnet/azurerm"
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  subnet_names        = ["subnet1", "subnet2", "subnet3"]
+
+  subnet_service_endpoints = {
+    subnet2 = ["Microsoft.Storage", "Microsoft.Sql"],
+    subnet3 = ["Microsoft.AzureActiveDirectory"]
+  }
+
+  subnet_enforce_private_link_endpoint_network_policies = {
+    "subnet2" = true,
+    "subnet3" = true
+  }
+
+  tags = {
+    environment = "dev"
+    costcenter  = "it"
+  }
+
+  depends_on = [azurerm_resource_group.example]
+}
+```
+
+## Example configuring private link service network policy
+
+```hcl
+module "vnet" {
+  source              = "Azure/vnet/azurerm"
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  subnet_names        = ["subnet1", "subnet2", "subnet3"]
+
+  subnet_service_endpoints = {
+    subnet2 = ["Microsoft.Storage", "Microsoft.Sql"],
+    subnet3 = ["Microsoft.AzureActiveDirectory"]
+  }
+
+  subnet_enforce_private_link_service_network_policies = {
+    "subnet3" = true
+  }
+
+  tags = {
+    environment = "dev"
+    costcenter  = "it"
+  }
+
+  depends_on = [azurerm_resource_group.example]
+}
+```
+
 ## Test
 
 ### Configurations

--- a/main.tf
+++ b/main.tf
@@ -13,12 +13,14 @@ resource azurerm_virtual_network "vnet" {
 }
 
 resource "azurerm_subnet" "subnet" {
-  count                = length(var.subnet_names)
-  name                 = var.subnet_names[count.index]
-  resource_group_name  = data.azurerm_resource_group.vnet.name
-  virtual_network_name = azurerm_virtual_network.vnet.name
-  address_prefixes     = [var.subnet_prefixes[count.index]]
-  service_endpoints    = lookup(var.subnet_service_endpoints, var.subnet_names[count.index], null)
+  count                                          = length(var.subnet_names)
+  name                                           = var.subnet_names[count.index]
+  resource_group_name                            = data.azurerm_resource_group.vnet.name
+  virtual_network_name                           = azurerm_virtual_network.vnet.name
+  address_prefixes                               = [var.subnet_prefixes[count.index]]
+  service_endpoints                              = lookup(var.subnet_service_endpoints, var.subnet_names[count.index], null)
+  enforce_private_link_endpoint_network_policies = lookup(var.subnet_enforce_private_link_endpoint_network_policies, var.subnet_names[count.index], false)
+  enforce_private_link_service_network_policies  = lookup(var.subnet_enforce_private_link_service_network_policies, var.subnet_names[count.index], false)
 }
 
 locals {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -48,6 +48,14 @@ module "vnet" {
     costcenter  = "it"
   }
 
+  subnet_enforce_private_link_endpoint_network_policies = {
+    subnet2 = true
+  }
+
+  subnet_enforce_private_link_service_network_policies = {
+    subnet3 = true
+  }
+
   depends_on = [azurerm_resource_group.test]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,18 @@ variable "subnet_service_endpoints" {
   default     = {}
 }
 
+variable "subnet_enforce_private_link_endpoint_network_policies" {
+  description = "A map of subnet name to enable/disable private link endpoint network policies on the subnet."
+  type        = map(any)
+  default     = {}
+}
+
+variable "subnet_enforce_private_link_service_network_policies" {
+  description = "A map of subnet name to enable/disable private link service network policies on the subnet."
+  type        = map(any)
+  default     = {}
+}
+
 variable "nsg_ids" {
   description = "A map of subnet name to Network Security Group IDs"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "subnet_service_endpoints" {
 
 variable "subnet_enforce_private_link_endpoint_network_policies" {
   description = "A map of subnet name to enable/disable private link endpoint network policies on the subnet."
-  type        = map(any)
+  type        = map(bool)
   default     = {}
 }
 
 variable "subnet_enforce_private_link_service_network_policies" {
   description = "A map of subnet name to enable/disable private link service network policies on the subnet."
-  type        = map(any)
+  type        = map(bool)
   default     = {}
 }
 


### PR DESCRIPTION
### Changes proposed in the pull request:

This PR will allow the enforcement of private link endpoint/service network policies per subnet when using the module. By default all enforcement's will be false (resource default).

**Example**

``` yaml
module "vnet" {
  source              = "Azure/vnet/azurerm"
  resource_group_name = azurerm_resource_group.example.name
  address_space       = ["10.0.0.0/16"]
  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
  subnet_names        = ["subnet1", "subnet2", "subnet3"]

  subnet_service_endpoints = {
    subnet2 = ["Microsoft.Storage", "Microsoft.Sql"],
    subnet3 = ["Microsoft.AzureActiveDirectory"]
  }

  subnet_enforce_private_link_endpoint_network_policies = {
    "subnet2" = true,
    "subnet3" = true
  }

  subnet_enforce_private_link_service_network_policies = {
    "subnet3" = true
  }

  tags = {
    environment = "dev"
    costcenter  = "it"
  }

  depends_on = [azurerm_resource_group.example]
}
```
