### PR TITLE
Revert changes pushed incorrectly

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "2.74.0"
+  hashes = [
+    "h1:gmx4I8DTW9RsSFCigIKR2XSdDM+fyPoQNrUDvDnwp8w=",
+    "zh:39770dfaaa2281ed0c8e620b9013ef96d45bc88a12ffff9df470b2da7c6f41df",
+    "zh:487d6920d1bc28cfda310dff43e0038e6621409b8746ca1d2937c177743d6194",
+    "zh:6b7f8224c63689e62e0178c7cf9fb21374ae840d646fe065c0b61902c77448df",
+    "zh:9e4810b85438905e417da01814dc2203a0e904d74b89f1d0330869ab71f88eaf",
+    "zh:ab09186cc1b7d4d92d0d85cd9f77dfb9d7b98992badb433156e5bf179c508bcd",
+    "zh:b9f11c240b05cfdd8b10da35848f269c16a8a0a2e6dfaaaf3982c6f4d9591266",
+    "zh:be35031ede79f8ab10fca9448def6b12ac1a81a748b1607f28345e7c341a9ad6",
+    "zh:caeaf6c93120df4f461d75d9f00c4ea493b3cd910e5d426dca34f74a27d36474",
+    "zh:d5e5eeafb61e8bb710f9f364a0352e38d783ca4584968bd0311a647bad9e84c1",
+    "zh:deda32842c89c5999148bfa045e0f9b0a17e7bd618c22ceb9dadb79f88d8c1f0",
+    "zh:ec7a4960b9960cd917fd727c9805afd23a48c5c6f5263701f8ef72f1107ed657",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -41,3 +41,12 @@ resource "azurerm_subnet_route_table_association" "vnet" {
   route_table_id = each.value
   subnet_id      = local.azurerm_subnets[each.key]
 }
+
+resource "azurerm_virtual_network_peering" "vnet_peering" {
+
+  count = length(var.vnet_peer_ids)
+  name                      = format("%s%s", "VNP", count.index)
+  resource_group_name       = data.azurerm_resource_group.vnet.name
+  virtual_network_name      = azurerm_virtual_network.vnet.name
+  remote_virtual_network_id = var.vnet_peer_ids[count.index]
+}

--- a/main.tf
+++ b/main.tf
@@ -48,4 +48,8 @@ resource "azurerm_virtual_network_peering" "vnet_peering" {
   resource_group_name       = data.azurerm_resource_group.vnet.name
   virtual_network_name      = azurerm_virtual_network.vnet.name
   remote_virtual_network_id = each.value.vnet_id
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> b403ae351ba79e74da188d5b8bb68abf0219d596

--- a/main.tf
+++ b/main.tf
@@ -43,10 +43,9 @@ resource "azurerm_subnet_route_table_association" "vnet" {
 }
 
 resource "azurerm_virtual_network_peering" "vnet_peering" {
-
-  count = length(var.vnet_peer_ids)
-  name                      = format("%s%s", "VNP", count.index)
+  for_each                  = { for rule in var.vnet_peer_ids : rule.name => rule }
+  name                      = each.value.name
   resource_group_name       = data.azurerm_resource_group.vnet.name
   virtual_network_name      = azurerm_virtual_network.vnet.name
-  remote_virtual_network_id = var.vnet_peer_ids[count.index]
+  remote_virtual_network_id = each.value.vnet_id
 }

--- a/test/fixture/.terraform.lock.hcl
+++ b/test/fixture/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "2.74.0"
+  hashes = [
+    "h1:gmx4I8DTW9RsSFCigIKR2XSdDM+fyPoQNrUDvDnwp8w=",
+    "zh:39770dfaaa2281ed0c8e620b9013ef96d45bc88a12ffff9df470b2da7c6f41df",
+    "zh:487d6920d1bc28cfda310dff43e0038e6621409b8746ca1d2937c177743d6194",
+    "zh:6b7f8224c63689e62e0178c7cf9fb21374ae840d646fe065c0b61902c77448df",
+    "zh:9e4810b85438905e417da01814dc2203a0e904d74b89f1d0330869ab71f88eaf",
+    "zh:ab09186cc1b7d4d92d0d85cd9f77dfb9d7b98992badb433156e5bf179c508bcd",
+    "zh:b9f11c240b05cfdd8b10da35848f269c16a8a0a2e6dfaaaf3982c6f4d9591266",
+    "zh:be35031ede79f8ab10fca9448def6b12ac1a81a748b1607f28345e7c341a9ad6",
+    "zh:caeaf6c93120df4f461d75d9f00c4ea493b3cd910e5d426dca34f74a27d36474",
+    "zh:d5e5eeafb61e8bb710f9f364a0352e38d783ca4584968bd0311a647bad9e84c1",
+    "zh:deda32842c89c5999148bfa045e0f9b0a17e7bd618c22ceb9dadb79f88d8c1f0",
+    "zh:ec7a4960b9960cd917fd727c9805afd23a48c5c6f5263701f8ef72f1107ed657",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:EPIax4Ftp2SNdB9pUfoSjxoueDoLc/Ck3EUoeX0Dvsg=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/test/fixture/.terraform.lock.hcl
+++ b/test/fixture/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version = "2.74.0"
   hashes = [
     "h1:gmx4I8DTW9RsSFCigIKR2XSdDM+fyPoQNrUDvDnwp8w=",
+    "h1:mVJLx0z3IFBM94jJPbzXajRyhh5xUHtuflp/Xtue104=",
     "zh:39770dfaaa2281ed0c8e620b9013ef96d45bc88a12ffff9df470b2da7c6f41df",
     "zh:487d6920d1bc28cfda310dff43e0038e6621409b8746ca1d2937c177743d6194",
     "zh:6b7f8224c63689e62e0178c7cf9fb21374ae840d646fe065c0b61902c77448df",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [
     "h1:EPIax4Ftp2SNdB9pUfoSjxoueDoLc/Ck3EUoeX0Dvsg=",
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
     "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -23,6 +23,20 @@ resource "azurerm_route_table" "rt1" {
   location            = var.vnet_location
 }
 
+resource "azurerm_virtual_network" "vnet1" {
+  name                = "test-${random_id.rg_name.hex}-vnet1"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = var.vnet_location
+  address_space       = ["11.0.0.0/16"]
+}
+
+resource "azurerm_virtual_network" "vnet2" {
+  name                = "test-${random_id.rg_name.hex}-vnet2"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = var.vnet_location
+  address_space       = ["12.0.0.0/16"]
+}
+
 module "vnet" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test.name
@@ -30,6 +44,7 @@ module "vnet" {
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
   vnet_location       = var.vnet_location
+  vnet_peer_ids       = [azurerm_virtual_network.vnet1.id, azurerm_virtual_network.vnet2.id]
 
   nsg_ids = {
     subnet1 = azurerm_network_security_group.nsg1.id

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -44,7 +44,20 @@ module "hub_vnet" {
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
   vnet_location       = var.vnet_location
+<<<<<<< HEAD
   vnet_peer_ids       = [azurerm_virtual_network.hub_vnet.id, azurerm_virtual_network.spoke_vnet.id]
+=======
+  vnet_peer_ids       = [
+    {
+      name = "foo2baz"
+      vnet_id = azurerm_virtual_network.vnet1.id
+    },
+    {
+      name = "foo2bar"
+      vnet_id = azurerm_virtual_network.vnet2.id
+    }
+  ]
+>>>>>>> b403ae351ba79e74da188d5b8bb68abf0219d596
 
   nsg_ids = {
     subnet1 = azurerm_network_security_group.nsg1.id

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -1,3 +1,7 @@
-output "test_vnet_id" {
-  value = module.vnet.vnet_id
+output "test_hub_vnet_id" {
+  value = module.hub_vnet.vnet_id
+}
+
+output "test_spoke_vnet_id" {
+  value = module.spoke_vnet.vnet_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -81,8 +81,26 @@ variable "vnet_location" {
   default     = null
 }
 
-variable "vnet_peer_ids"{
+# variable "vnet_peer_ids"{
+#   description = "A list of Azure resource IDs of the remote virtual network. Changing this forces a new resource to be created"
+#   type        = list(string)
+#   default     = []
+# }
+
+variable "vnet_peer_ids" {
+  type        = list(map(string))
   description = "A list of Azure resource IDs of the remote virtual network. Changing this forces a new resource to be created"
-  type        = list(string)
-  default     = []
+
+  # Example:
+
+  # [
+  #   {
+  #     name = "foo2baz"
+  #     vnet_id = azurerm_virtual_network.vnet1.id
+  #   },
+  #   {
+  #     name = "foo2bar"
+  #     vnet_id = azurerm_virtual_network.vnet2.id
+  #   }
+  # ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,9 @@ variable "vnet_location" {
   type        = string
   default     = null
 }
+
+variable "vnet_peer_ids"{
+  description = "A list of Azure resource IDs of the remote virtual network. Changing this forces a new resource to be created"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-vnet .
$ docker run --rm azure-vnet /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


