### PR TITLE
Added new output "vnet_subnets_name_id"

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,7 @@ output "vnet_subnets" {
   description = "The ids of subnets created inside the newl vNet"
   value       = azurerm_subnet.subnet.*.id
 }
+output "vnet_subnets_name_id" {
+  description = "Can be queried subnet-id by subnet name by using lookup(module.vnet.vnet_subnets_name_id, subnet1)"
+  value       = local.azurerm_subnets
+}


### PR DESCRIPTION
Can be query subnet id by subnet name this will help to refer in subsequent resource creation where it requires subnet ID, For example, need subnet ID to Application Gateway
  Here is the example 
locals {
  frontend_subnet_id             = lookup(module.vnet.vnet_subnets_name_id, subnet1)
} 
The current output "vnet_subnets"  it not user friendly which i feel

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-vnet .
$ docker run --rm azure-vnet /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


