### PR TITLE
Added 3 default subnet_prefixes to the subnet list in variables.tf  m…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "dns_servers" {
 variable "subnet_prefixes" {
   description = "The address prefix to use for the subnet."
   type        = list(string)
-  default     = ["10.0.1.0/24"]
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 variable "subnet_names" {


### PR DESCRIPTION

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-vnet .
$ docker run --rm azure-vnet /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #001

Changes proposed in the pull request:

I've added 3 default subnet_prefixes to the list in variables.tf so that it matches the 3 default subnet_names. This will help people to run/test the code without adding any optional variables, especially people that are just starting to learn Terraform modules. 

Without this fix, Terraform Plan throws the following error when you run it without adding subnet_prefixes (or names): 
Error: Invalid index
│ 
│   on .terraform/modules/vnet/main.tf line 20, in resource "azurerm_subnet" "subnet":
│   20:   address_prefixes                               = [var.subnet_prefixes[count.index]]
│     ├────────────────
│     │ count.index is 1
│     │ var.subnet_prefixes is list of string with 1 element
│ 
│ The given key does not identify an element in this collection value: the
│ given index is greater than or equal to the length of the collection.
╵
╷
│ Error: Invalid index
│ 
│   on .terraform/modules/vnet/main.tf line 20, in resource "azurerm_subnet" "subnet":
│   20:   address_prefixes                               = [var.subnet_prefixes[count.index]]
│     ├────────────────
│     │ count.index is 2
│     │ var.subnet_prefixes is list of string with 1 element
│ 
│ The given key does not identify an element in this collection value.

