### PR TITLE
fix: correct typo in description of vnet_subnets output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,6 @@ output "vnet_address_space" {
 }
 
 output "vnet_subnets" {
-  description = "The ids of subnets created inside the newl vNet"
+  description = "The ids of subnets created inside the newly created vNet"
   value       = azurerm_subnet.subnet.*.id
 }


### PR DESCRIPTION
this is just a quick fix for a typo I noticed while using this module.