### PR TITLE
Fix resource group circular dependency if vnet_location is specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,13 @@
 #Azure Generic vNet Module
 data "azurerm_resource_group" "vnet" {
-  name = var.resource_group_name
+  count = var.vnet_location != null ? 0 : 1
+  name  = var.resource_group_name
 }
 
 resource "azurerm_virtual_network" "vnet" {
   name                = var.vnet_name
-  resource_group_name = data.azurerm_resource_group.vnet.name
-  location            = var.vnet_location != null ? var.vnet_location : data.azurerm_resource_group.vnet.location
+  resource_group_name = var.resource_group_name
+  location            = var.vnet_location != null ? var.vnet_location : data.azurerm_resource_group.vnet[0].location
   address_space       = var.address_space
   dns_servers         = var.dns_servers
   tags                = var.tags
@@ -15,7 +16,7 @@ resource "azurerm_virtual_network" "vnet" {
 resource "azurerm_subnet" "subnet" {
   count                                          = length(var.subnet_names)
   name                                           = var.subnet_names[count.index]
-  resource_group_name                            = data.azurerm_resource_group.vnet.name
+  resource_group_name                            = var.resource_group_name
   virtual_network_name                           = azurerm_virtual_network.vnet.name
   address_prefixes                               = [var.subnet_prefixes[count.index]]
   service_endpoints                              = lookup(var.subnet_service_endpoints, var.subnet_names[count.index], null)


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-vnet .
$ docker run --rm azure-vnet /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #62 

Changes proposed in the pull request:
If vnet_location is specified then the data resource isn't required and the circular dependency on the resource group is removed.

Note there is another way of fixing this which may be more of a long-term fix in #43 