### PR TITLE
add ddos_protection_plan configuration to vnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,14 @@ resource "azurerm_virtual_network" "vnet" {
   address_space       = var.address_space
   dns_servers         = var.dns_servers
   tags                = var.tags
+  dynamic "ddos_protection_plan" {
+    for_each = var.ddos_protection_plan
+
+    content {
+      enable = ddos_protection_plan.value["enable"]
+      id     = ddos_protection_plan.value["id"]
+    }
+  }
 }
 
 resource "azurerm_subnet" "subnet" {

--- a/main.tf
+++ b/main.tf
@@ -10,12 +10,13 @@ resource "azurerm_virtual_network" "vnet" {
   address_space       = var.address_space
   dns_servers         = var.dns_servers
   tags                = var.tags
+
   dynamic "ddos_protection_plan" {
-    for_each = var.ddos_protection_plan
+    for_each = var.ddos_protection_plan != null ? [var.ddos_protection_plan] : []
 
     content {
-      enable = ddos_protection_plan.value["enable"]
-      id     = ddos_protection_plan.value["id"]
+      enable = ddos_protection_plan.value.enable
+      id     = ddos_protection_plan.value.id
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,12 +88,10 @@ variable "vnet_location" {
 }
 
 variable "ddos_protection_plan" {
-  description = "The set of DDos protection plan configuration"
-  type = set(object(
-    {
-      enable = bool
-      id     = string
-    }
-  ))
-  default = []
+  description = "The set of DDoS protection plan configuration"
+  type = object({
+    enable = bool
+    id     = string
+  })
+  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -86,3 +86,14 @@ variable "vnet_location" {
   type        = string
   default     = null
 }
+
+variable "ddos_protection_plan" {
+  description = "The set of DDos protection plan configuration"
+  type = set(object(
+    {
+      enable = bool
+      id     = string
+    }
+  ))
+  default = []
+}


### PR DESCRIPTION
Modify vnet's ddos protection plan to be configurable.
The default value is 'null', so set it only when it is necessary.

Input variable example 
```
module "vnet" {
  source              = "Azure/vnet/azurerm"
  
  ...
  ddos_protection_plan = {
      enable = true
      id     = azurerm_network_ddos_protection_plan.ddos_protection_plan.id
  }
}
```

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-vnet .
$ docker run --rm azure-vnet /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:
