### PR TITLE
Remove datasource `azurerm_resource_group.vnet`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,12 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                                                                | Type        |
-|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [azurerm_subnet.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                                                                     | resource    |
-| [azurerm_subnet_network_security_group_association.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource    |
-| [azurerm_subnet_route_table_association.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association)                       | resource    |
-| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network)                                                     | resource    |
-| [azurerm_resource_group.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                    | data source |
+| Name                                                                                                                                                                                | Type     |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| [azurerm_subnet.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                                                                     | resource |
+| [azurerm_subnet_network_security_group_association.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_route_table_association.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association)                       | resource |
+| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network)                                                     | resource |
 
 ## Inputs
 
@@ -154,7 +153,7 @@ No modules.
 | <a name="input_subnet_prefixes"></a> [subnet\_prefixes](#input\_subnet\_prefixes)                                                                                                                             | The address prefix to use for the subnet.                                                    | `list(string)`                                                          | <pre>[<br>  "10.0.1.0/24"<br>]</pre>                             |    no    |
 | <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints)                                                                                                | A map of subnet name to service endpoints to add to the subnet.                              | `map(any)`                                                              | `{}`                                                             |    no    |
 | <a name="input_tags"></a> [tags](#input\_tags)                                                                                                                                                                | The tags to associate with your network and subnets.                                         | `map(string)`                                                           | <pre>{<br>  "ENV": "test"<br>}</pre>                             |    no    |
-| <a name="input_vnet_location"></a> [vnet\_location](#input\_vnet\_location)                                                                                                                                   | The location of the vnet to create. Defaults to the location of the resource group.          | `string`                                                                | `null`                                                           |    no    |
+| <a name="input_vnet_location"></a> [vnet\_location](#input\_vnet\_location)                                                                                                                                   | The location of the vnet to create.                                                          | `string`                                                                | n/a                                                              |   yes    |
 | <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name)                                                                                                                                               | Name of the vnet to create                                                                   | `string`                                                                | `"acctvnet"`                                                     |    no    |
 
 ## Outputs

--- a/examples/new_route/main.tf
+++ b/examples/new_route/main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "example" {
 module "vnet" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.example.name
+  vnet_location       = var.location
   address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
-
   route_tables_ids = {
     subnet1 = azurerm_route_table.example.id
     subnet2 = azurerm_route_table.example.id

--- a/examples/new_security_rule/main.tf
+++ b/examples/new_security_rule/main.tf
@@ -11,6 +11,7 @@ module "vnet" {
   source = "../../"
 
   resource_group_name = azurerm_resource_group.example.name
+  vnet_location       = var.location
   address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]

--- a/examples/private_link_endpoint/main.tf
+++ b/examples/private_link_endpoint/main.tf
@@ -10,6 +10,7 @@ resource "azurerm_resource_group" "example" {
 module "vnet" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.example.name
+  vnet_location       = var.location
   address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]

--- a/examples/private_link_service/main.tf
+++ b/examples/private_link_service/main.tf
@@ -10,6 +10,7 @@ resource "azurerm_resource_group" "example" {
 module "vnet" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.example.name
+  vnet_location       = var.location
   address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,8 @@
-#Azure Generic vNet Module
-data "azurerm_resource_group" "vnet" {
-  name = var.resource_group_name
-}
-
 resource "azurerm_virtual_network" "vnet" {
   address_space       = var.address_space
-  location            = var.vnet_location != null ? var.vnet_location : data.azurerm_resource_group.vnet.location
+  location            = var.vnet_location
   name                = var.vnet_name
-  resource_group_name = data.azurerm_resource_group.vnet.name
+  resource_group_name = var.resource_group_name
   dns_servers         = var.dns_servers
   tags                = var.tags
 
@@ -26,7 +21,7 @@ resource "azurerm_subnet" "subnet" {
 
   address_prefixes                               = [var.subnet_prefixes[count.index]]
   name                                           = var.subnet_names[count.index]
-  resource_group_name                            = data.azurerm_resource_group.vnet.name
+  resource_group_name                            = var.resource_group_name
   virtual_network_name                           = azurerm_virtual_network.vnet.name
   enforce_private_link_endpoint_network_policies = lookup(var.subnet_enforce_private_link_endpoint_network_policies, var.subnet_names[count.index], false)
   enforce_private_link_service_network_policies  = lookup(var.subnet_enforce_private_link_service_network_policies, var.subnet_names[count.index], false)

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "resource_group_name" {
   description = "Name of the resource group to be imported."
   type        = string
+  nullable    = false
 }
 
 variable "vnet_location" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "vnet_location" {
+  description = "The location of the vnet to create."
+  type        = string
+  nullable    = false
+}
+
 variable "address_space" {
   type        = list(string)
   description = "The address space that is used by the virtual network."
@@ -82,12 +88,6 @@ variable "tags" {
   default = {
     ENV = "test"
   }
-}
-
-variable "vnet_location" {
-  description = "The location of the vnet to create. Defaults to the location of the resource group."
-  type        = string
-  default     = null
 }
 
 variable "vnet_name" {


### PR DESCRIPTION
Remove datasource `azurerm_resource_group.vnet`.
Make `var.vnet_location` required.
This change is a breaking change, and it will fix #62.