### PR TITLE
Limit `azurerm`'s version to `>= 3.11, < 4.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ Originally created by [Eugene Chuvyrov](http://github.com/echuvyrov)
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name                                                                      | Version |
-|---------------------------------------------------------------------------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2  |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)       | >= 3.11 |
+| Name                                                                      | Version        |
+|---------------------------------------------------------------------------|----------------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2         |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)       | >= 3.11, < 4.0 |
 
 ## Providers
 
-| Name                                                          | Version |
-|---------------------------------------------------------------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.11 |
+| Name                                                          | Version        |
+|---------------------------------------------------------------|----------------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.11, < 4.0 |
 
 ## Modules
 

--- a/examples/all_default/providers.tf
+++ b/examples/all_default/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.11.0"
+      version = ">=3.11.0, <4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/complete/providers.tf
+++ b/examples/complete/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.11.0"
+      version = ">=3.11.0, <4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/new_route/providers.tf
+++ b/examples/new_route/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.11.0"
+      version = ">=3.11.0, <4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/new_security_rule/providers.tf
+++ b/examples/new_security_rule/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.11.0"
+      version = ">=3.11.0, <4.0"
     }
     curl = {
       source  = "anschoewe/curl"

--- a/examples/private_link_endpoint/providers.tf
+++ b/examples/private_link_endpoint/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.11.0"
+      version = ">=3.11.0, <4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/private_link_service/providers.tf
+++ b/examples/private_link_service/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.11.0"
+      version = ">=3.11.0, <4.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.11"
+      version = ">= 3.11, < 4.0"
     }
   }
 }


### PR DESCRIPTION
Limit `azurerm`'s version to `>= 3.11, < 4.0` because `enforce_private_link_endpoint_network_policies` will be removed in `4.0` and we cannot use `private_endpoint_network_policies_enabled` yet. To avoid potential breaking changes, we'd better limit provider's version.

This pr should solve #69.