### PR TITLE
Capture the iterator variable to avoid concurrent test error

### DIFF
--- a/test/e2e/terraform_test.go
+++ b/test/e2e/terraform_test.go
@@ -20,11 +20,12 @@ func TestExamples(t *testing.T) {
 		"examples/private_link_service",
 	}
 	for _, example := range examples {
-		t.Run(fmt.Sprintf("%s_for_each", example), func(t *testing.T) {
-			testExample(t, example, true)
+		e := example
+		t.Run(fmt.Sprintf("%s_for_each", e), func(t *testing.T) {
+			testExample(t, e, true)
 		})
-		t.Run(fmt.Sprintf("%s_count", example), func(t *testing.T) {
-			testExample(t, example, false)
+		t.Run(fmt.Sprintf("%s_count", e), func(t *testing.T) {
+			testExample(t, e, false)
 		})
 	}
 }

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -18,11 +18,12 @@ func TestExamples(t *testing.T) {
 		"examples/private_link_service",
 	}
 	for _, example := range examples {
-		t.Run(fmt.Sprintf("%s_for_each", example), func(t *testing.T) {
-			testExample(t, example, true)
+		e := example
+		t.Run(fmt.Sprintf("%s_for_each", e), func(t *testing.T) {
+			testExample(t, e, true)
 		})
-		t.Run(fmt.Sprintf("%s_count", example), func(t *testing.T) {
-			testExample(t, example, false)
+		t.Run(fmt.Sprintf("%s_count", e), func(t *testing.T) {
+			testExample(t, e, false)
 		})
 	}
 }


### PR DESCRIPTION
## Describe your changes

We have a classic `foreach` error in our go test code, it would cause randomly error when we try to execute tests concurrently, this pull request capture the iterator variable into a local variable to avoid such error.

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

