### PR TITLE
Remove DNS configuration from module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,6 @@ resource "azurerm_virtual_network" "vnet" {
   name                = var.vnet_name
   resource_group_name = var.resource_group_name
   bgp_community       = var.bgp_community
-  dns_servers         = var.dns_servers
   tags = merge(var.tags, (/*<box>*/ (var.tracing_tags_enabled ? { for k, v in /*</box>*/ {
     avm_git_commit           = "2b2f05969200c71b6609f4cdfa9120d48af55537"
     avm_git_file             = "main.tf"
@@ -23,6 +22,10 @@ resource "azurerm_virtual_network" "vnet" {
       enable = ddos_protection_plan.value.enable
       id     = ddos_protection_plan.value.id
     }
+  }
+
+  lifecycle {
+    ignore_changes = [dns_servers]
   }
 }
 
@@ -101,4 +104,11 @@ resource "azurerm_subnet_route_table_association" "vnet" {
 
   route_table_id = each.value
   subnet_id      = local.azurerm_subnets_name_id_map[each.key]
+}
+
+resource "azurerm_virtual_network_dns_servers" "vnet_dns" {
+  count = length(var.dns_servers) > 0 ? 1 : 0
+
+  dns_servers        = var.dns_servers
+  virtual_network_id = azurerm_virtual_network.vnet.id
 }

--- a/main.tf
+++ b/main.tf
@@ -105,10 +105,3 @@ resource "azurerm_subnet_route_table_association" "vnet" {
   route_table_id = each.value
   subnet_id      = local.azurerm_subnets_name_id_map[each.key]
 }
-
-resource "azurerm_virtual_network_dns_servers" "vnet_dns" {
-  count = length(var.dns_servers) > 0 ? 1 : 0
-
-  dns_servers        = var.dns_servers
-  virtual_network_id = azurerm_virtual_network.vnet.id
-}

--- a/variables.tf
+++ b/variables.tf
@@ -37,13 +37,6 @@ variable "ddos_protection_plan" {
   description = "The set of DDoS protection plan configuration"
 }
 
-# If no values specified, this defaults to Azure DNS
-variable "dns_servers" {
-  type        = list(string)
-  default     = []
-  description = "The DNS servers to be used with vNet."
-}
-
 variable "nsg_ids" {
   type = map(string)
   default = {


### PR DESCRIPTION
## Describe your changes
DNS cannot be set in the module for VNet creation. In most cases, the custom DNS will be a Private DNS resolver that lives inside the VNet. The resolver would be created outside the module and would require the VNet Id in order to create Subnet and other resources. The correct method for setting VNet DNS is to use the `azurerm_virtual_network_dns_servers` resource after the VNet is created. That's what I did to work around the circular ref issue trying to supply the value to the module. But after every apply, this module wants to remove the `dns_servers` setting I configured with `azurerm_virtual_network_dns_servers`. 

This change ignores the `dns_servers` setting to allow configuration to be applied without issue.

## Issue number

None

## Checklist before requesting a review
- [X] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [X] I have executed pre-commit on my machine
- [X] I have passed pr-check on my machine

Thanks for your cooperation!

